### PR TITLE
Added permissions to setClaimRewardsOnWithdrawAll and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ __pycache__
 build/
 reports/
 .env
-
+venv/
 node_modules/

--- a/_setup/config.py
+++ b/_setup/config.py
@@ -4,7 +4,7 @@ WANT = "0xDA0053F0bEfCbcaC208A3f867BB243716734D809"
 WFTM = "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83"
 
 ## Account that has a lot of want (we will "borrow it" for testing)
-WHALE_ADDRESS = "0xDA002DF66B625C730e5FEDE90D2F231f2aC935ff"
+WHALE_ADDRESS = "0xDA0067ec0925eBD6D583553139587522310Bec60"
 ## Address for Badger Registry, used to fill in default addresses
 ## See: https://github.com/Badger-Finance/badger-registry
 REGISTRY = "0xFda7eB6f8b7a9e9fCFd348042ae675d1d652454f"

--- a/contracts/OxSolidStaker.sol
+++ b/contracts/OxSolidStaker.sol
@@ -54,6 +54,7 @@ contract OxSolidStaker is BaseStrategy {
     function setClaimRewardsOnWithdrawAll(bool _claimRewardsOnWithdrawAll)
         external
     {
+        _onlyGovernanceOrStrategist();
         claimRewardsOnWithdrawAll = _claimRewardsOnWithdrawAll;
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def want(deployer):
     token = interface.IERC20Detailed(TOKEN_ADDRESS)
     WHALE = accounts.at(WHALE_ADDRESS, force=True)  ## Address with tons of token
 
-    token.transfer(deployer, token.balanceOf(WHALE), {"from": WHALE})
+    token.transfer(deployer, token.balanceOf(WHALE)/4, {"from": WHALE}) ## Taking a portion as it is a SC
     return token
 
 

--- a/tests/integration/test_strategy_permissions.py
+++ b/tests/integration/test_strategy_permissions.py
@@ -82,13 +82,21 @@ def test_strategy_action_permissions(deployer, vault, strategy, want, keeper):
         strategy.keeper(),
     ]
 
-    # withdrawToVault onlyVault
+    # withdrawToVault onlyVault 
     for actor in actorsToCheck:
         if actor == strategy.governance() or actor == strategy.strategist():
             vault.withdrawToVault({"from": actor})
         else:
             with brownie.reverts("onlyGovernanceOrStrategist"):
                 vault.withdrawToVault({"from": actor})
+
+    # setClaimRewardsOnWithdrawAll _onlyGovernanceOrStrategist()
+    for actor in actorsToCheck:
+        if actor == strategy.governance() or actor == strategy.strategist():
+            strategy.setClaimRewardsOnWithdrawAll(False, {"from": actor})
+        else:
+            with brownie.reverts("onlyGovernanceOrStrategist"):
+                strategy.setClaimRewardsOnWithdrawAll(False, {"from": actor})
 
     # withdraw onlyVault
     for actor in actorsToCheck:

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -35,6 +35,11 @@ def test_claimRewardsOnWithdrawAll(deployer, vault, strategy, want, governance, 
     assert oxd.balanceOf(strategy) > 0
 
     chain.revert()
+
+    # Random can't call
+    with brownie.reverts("onlyGovernanceOrStrategist"):
+      strategy.setClaimRewardsOnWithdrawAll(False, {"from": accounts[5]})
+
     strategy.setClaimRewardsOnWithdrawAll(False)
 
     vault.withdrawToVault({"from": governance})


### PR DESCRIPTION
Added only gov and strategist permissions to the `setClaimRewardsOnWithdrawAll` function. Additionally, included this function on the permissions test.

Modified tests passing:
![image](https://user-images.githubusercontent.com/25463788/157976268-1090bb67-ced2-491b-9d01-9661806b20f1.png)

![image](https://user-images.githubusercontent.com/25463788/157976251-bb134c6d-2501-49c7-8d56-b319c761f18b.png)
